### PR TITLE
feat: Aperiodic C signal

### DIFF
--- a/src/nci.py
+++ b/src/nci.py
@@ -141,7 +141,7 @@ def generate_nci(f_m: float, f_s: float, size: int) -> NDArray:
     """
 
     N = 2**8
-    C_AMPLITUDE = 64
+    C_AMPLITUDE = 256
     # create c by concatenating copies of x's
     c = np.concat([generate_random_signal(f_m, f_s, N) for i in range(int(np.ceil(size/N)))])
     c = c[:size]


### PR DESCRIPTION
Instead of repeating the same 1024 IFFT to fill up c, generate a new IFFT of size 256 to fill up c.

Magnitude/phase plot of new C signal:
As alluded before, the transition between one code to the next generates components outside the bandlimit of 9Hz.
<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/bb98a75e-80a4-4dde-9542-270f4cada061" />
<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/46fc5e97-557a-4524-bf6a-294f5d892ebb" />

Looks like alignment matrix is still working with window size of 256:
<img width="417" height="480" alt="image" src="https://github.com/user-attachments/assets/af1f3cc5-a449-40f6-96c4-7c1b2e9e44a1" />

