### PR TITLE
feat: 256x256 RGB NCI video simulation

### DIFF
--- a/src/align-mat.py
+++ b/src/align-mat.py
@@ -31,34 +31,35 @@ def main():
     # Simulate malicious video cut
     y = np.concatenate((y[:500], y[700:]))
 
-    window_size = 256
-    print("Creating sliding windows...")
-    c_prime_windows = sliding_window_view(c, window_size, writeable=True)
-    # c_prime_windows axes = (window_index, sample_index)
-    y_windows = sliding_window_view(y, (window_size,1,1,1), writeable=True).squeeze().reshape(-1, VIDEO_WIDTH*VIDEO_HEIGHT*VIDEO_CHANNEL, window_size)
-    # rearrange y_windows axes to (pixel_index, window_index, sample_index)
-    y_windows = y_windows.transpose((1, 0, 2))
+    # Create global vector y by reducing each frame to a single value
+    y = np.mean(y, axis=(1,2,3))
 
-    print(f"c_prime_windows shape: {c_prime_windows.shape}")
-    print(f"y_windows shape: {y_windows.shape}")
+    window_size = 512
+    print("Creating sliding windows...")
+    c_prime_windows = sliding_window_view(np.concat([c, c[:window_size-1]]), window_size, writeable=True)
+    # c_prime_windows axes = (window_index, sample_index)
+    y_windows = sliding_window_view(np.concat([y, y[:window_size-1]]), window_size, writeable=True)
+
+    print(f"{c_prime_windows.shape=}")
+    print(f"{y_windows.shape=}")
 
     # Convert to PyTorch tensors and move to GPU
     c_prime_windows_torch = torch.from_numpy(c_prime_windows).float().to(device)
     y_windows_torch = torch.from_numpy(y_windows).float().to(device)
 
     # Perform matrix multiplication on GPU/MPS (or by default your CPU)
-    x = torch.matmul(y_windows_torch, c_prime_windows_torch.T).transpose(0, 1).transpose(1, 2)
-    x = torch.mean(x, dim=2)
-    x = x.T
+    align_mat = torch.matmul(y_windows_torch, c_prime_windows_torch.T)
+    align_mat = align_mat.T
+    print(align_mat)
 
     # Move result back to CPU and convert to NumPy
-    x = x.cpu().numpy()
-    print(f"x shape: {x.shape}")
+    align_mat = align_mat.cpu().numpy()
+    print(f"{align_mat.shape=}")
     elapsed_time = time.time() - start_time
     print(f"Computation time: {elapsed_time:.4f} seconds")
 
     fig = plt.figure(figsize=(16, 9))
-    plt.matshow(x)
+    plt.matshow(align_mat)
     plt.title("Alignment Matrix (GPU-Accelerated)")
     plt.xlabel("Y index")
     plt.ylabel("C index")

--- a/src/nci.py
+++ b/src/nci.py
@@ -13,8 +13,8 @@ rng = np.random.default_rng()
 
 def main():
     # generate 60 second NCI video @ 30fps
-    VIDEO_WIDTH = 16
-    VIDEO_HEIGHT = 16
+    VIDEO_WIDTH = 256
+    VIDEO_HEIGHT = 256
     VIDEO_FPS = 30
     VIDEO_DURATION = 60
     FRAME_COUNT = VIDEO_FPS*VIDEO_DURATION
@@ -163,7 +163,7 @@ def generate_nci(f_m: float, f_s: float, size: int) -> NDArray:
         NDArray: Array representing noise coded light intensity over time
     """
 
-    N = 2**10
+    N = 16
     C_AMPLITUDE = 1
     # create c by concatenating copies of x's
     c = np.concat([generate_random_signal(f_m, f_s, N) for i in range(int(np.ceil(size/N)))])


### PR DESCRIPTION
# Changes
1. Add 3 color channels to convert greyscale NCI video simulation to RGB NCI video simulation.
2. Normalizes all array values (c, y, l, n, etc) to range [0,1].
3. Reduce FFT bin count to 16
4. Instead of generating multiple alignment matrices for each pixel/color and averaging the matrices, first generate a 1d global vector (see section 4.1 of paper) by averaging across the last 3 dimensions (width, height, channel) of 4d vector `y` then use that global vector to generate a single alignment matrix. This also significantly reduces computation.
5. Wrap around c and y vectors to ensure that the number of window views equals the number of original samples. Without this, taking a window view always reduces the number of total samples.
6. Set window size to 512 since paper used window size of 450.

resolves #24

Static 256x256 RGB scene:
<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/e1e54b35-119e-4a92-afbc-e9e2a4afc879" />

Alignment matrix (frame 500~700 cut out):
<img width="426" height="480" alt="image" src="https://github.com/user-attachments/assets/da9bbcbf-b1b0-455c-93c0-d54f233f12e7" />

C magnitude spectrum:
<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/a2817d9a-a3f0-452d-b1a9-a4c751e713b9" />

C distribution:
<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/a9f3278a-1010-4cf4-9c25-7d0c7bb05624" />

Photon Shot noise (n) distribution:
<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/39ed650d-625c-4b8a-a24d-5e3c8b7633e6" />

Y distribution:
<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/34dc242f-2569-4a35-862d-945fca17cfd5" />

Plot of top left pixel value (3 color channels):
<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/e91bbd0a-2c14-44d0-a259-02ab1091c059" />
